### PR TITLE
Fix compile errors from new dynamo rio

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,16 @@
 .PHONY: all dynamorio client clean dependencies
 
-EXECUTABLES = git cmake gnuplot g++ python
+EXECUTABLES = git cmake gnuplot g++ python3
 K := $(foreach exec,$(EXECUTABLES),\
         $(if $(shell which $(exec)),ok,$(error "No $(exec) in PATH")))
 
-all: dependencies dynamorio client
+all: dependencies dynamorio/build/bin64/drrun client
 
 dependencies: ert
 
-dynamorio:
+dynamorio/build/bin64/drrun:
 	git clone https://github.com/DynamoRIO/dynamorio.git
-	cd dynamorio; mkdir build; cd build; cmake ..; make -j
+	cd dynamorio; git submodule init; git submodule update; mkdir build; cd build; cmake ..; make -j
 
 ert:
 	git clone https://bitbucket.org/berkeleylab/cs-roofline-toolkit ert

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -1,6 +1,7 @@
 ## Andrea Brunato andrea.brunato@arm.com
 ## Make it easily defined by the user
 
+project(roofline)
 cmake_minimum_required(VERSION 2.8)
 
 set (CMAKE_CXX_FLAGS "-Wall -Werror=implicit-function-declaration")

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -55,6 +55,12 @@
 #include "drsyms.h"
 #include "droption.h"
 
+using ::dynamorio::droption::droption_parser_t;
+using ::dynamorio::droption::DROPTION_SCOPE_ALL;
+using ::dynamorio::droption::DROPTION_SCOPE_FRONTEND;
+using ::dynamorio::droption::DROPTION_SCOPE_CLIENT;
+using ::dynamorio::droption::droption_t;
+
 
 static client_id_t client_id;
 
@@ -71,8 +77,8 @@ static int roi_end_detected = 0;
 
 typedef struct{
 	std::string f_name;
-	void (*f_pre)(void* wrapcxt, OUT void **user_data);
-	void (*f_post)(void* wrapcxt, OUT void *user_data);
+	void (*f_pre)(void* wrapcxt, DR_PARAM_OUT void **user_data);
+	void (*f_post)(void* wrapcxt, DR_PARAM_OUT void *user_data);
 } wrap_callback_t;
 
 
@@ -198,7 +204,7 @@ static std::string get_src_file_name(void *wrapcxt, droption_t<std::string> user
 }
 
 
-static void event_roi_init(void *wrapcxt, OUT void**user_data){
+static void event_roi_init(void *wrapcxt, DR_PARAM_OUT void**user_data){
 #ifdef VALIDATE
 	dr_printf(">> ROI Start <<\n");
 #endif
@@ -237,7 +243,7 @@ static void event_roi_init(void *wrapcxt, OUT void**user_data){
 
 
 // This function is almost equivalent to event_roi_end but it's wrapped in a post function execution scenario
-static void symbol_roi_end(void *wrapcxt, OUT void *user_data){
+static void symbol_roi_end(void *wrapcxt, DR_PARAM_OUT void *user_data){
 
 #ifdef VALIDATE
 	dr_printf(">> Symbol ROI End <<\n");
@@ -271,7 +277,7 @@ static void symbol_roi_end(void *wrapcxt, OUT void *user_data){
 
 
 
-static void event_roi_end(void *wrapcxt, OUT void **user_data){
+static void event_roi_end(void *wrapcxt, DR_PARAM_OUT void **user_data){
 
 #ifdef VALIDATE
 	dr_printf(">> ROI End <<\n");

--- a/client/point.hpp
+++ b/client/point.hpp
@@ -6,6 +6,7 @@
 #include"dr_api.h"
 #include"droption.h"
 
+using ::dynamorio::droption::droption_t;
 
 extern droption_t<bool> time_run;
 


### PR DESCRIPTION
There were namespace changes to dynamo rio that created compile problem.  This patch fixes those errors.